### PR TITLE
Add message templates and view model for chat messages

### DIFF
--- a/BankAppDesktop/App.xaml
+++ b/BankAppDesktop/App.xaml
@@ -9,6 +9,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+                <ResourceDictionary Source="Resources/MessageTemplates.xaml" />
                 <!-- Other merged dictionaries here -->
             </ResourceDictionary.MergedDictionaries>
             <!-- Other app resources here -->

--- a/BankAppDesktop/Resources/MessageTemplates.xaml
+++ b/BankAppDesktop/Resources/MessageTemplates.xaml
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!-- Text Message Templates -->
+    <DataTemplate x:Key="TextMessageTemplateLeft">
+        <Grid HorizontalAlignment="Left">
+            <StackPanel>
+                <!-- Display Sender's Name -->
+                <TextBlock Text="{Binding SenderUsername}" Foreground="LightGray" 
+                       FontSize="12" FontWeight="Bold" Margin="5,0,5,2"/>
+                <Grid>
+                    <Border Background="#39374f" Padding="10" CornerRadius="10" Margin="5"
+                        MaxWidth="400">
+                        <TextBlock Text="{Binding Content}" Foreground="White" 
+                               TextWrapping="Wrap" FontFamily="Segoe UI Emoji"/>
+                    </Border>
+                    <!-- Menu button for left messages (positioned on right side) -->
+                    <Button HorizontalAlignment="Right" VerticalAlignment="Top" 
+                            Background="Transparent" BorderThickness="0" Margin="0,0,-30,0"
+                            Width="30" Height="30">
+                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE10C;" Foreground="LightGray"/>
+                        <Button.Flyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem Text="Report" Icon="ReportHacked" Command="{Binding DataContext.ReportMessageCommand, ElementName=chatMessagesView}"
+CommandParameter="{Binding}"/>
+                            </MenuFlyout>
+                        </Button.Flyout>    
+                    </Button>
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="TextMessageTemplateRight">
+        <Grid HorizontalAlignment="Right">
+            <StackPanel>
+                <!-- Added Sender's Name -->
+                <TextBlock Text="{Binding SenderUsername}" Foreground="LightGray" 
+                       FontSize="12" FontWeight="Bold" Margin="5,0,5,2"
+                       HorizontalAlignment="Right"/>
+                <Grid>
+                    <!-- Menu button for right messages (positioned on left side) -->
+                    <Button HorizontalAlignment="Left" VerticalAlignment="Top" 
+                            Background="Transparent" BorderThickness="0" Margin="-30,0,0,0"
+                            Width="30" Height="30">
+                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE10C;" Foreground="LightGray"/>
+                        <Button.Flyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem Text="Delete" 
+                                                Icon="Delete"
+                                                Command="{Binding DataContext.DeleteMessageCommand, ElementName=chatMessagesView}"
+                                                CommandParameter="{Binding}"/>
+                                <MenuFlyoutItem Text="Report" Icon="ReportHacked" Command="{Binding DataContext.ReportMessageCommand, ElementName=chatMessagesView}"
+CommandParameter="{Binding}"/>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+                    <Border Background="#4e6e8e" Padding="10" CornerRadius="10" Margin="5"
+                            MaxWidth="400">
+                        <TextBlock Text="{Binding Content}" Foreground="White" TextWrapping="Wrap" FontFamily="Segoe UI Emoji"/>
+                    </Border>
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+
+    <!-- Image Message Templates -->
+    <DataTemplate x:Key="ImageMessageTemplateLeft">
+        <Grid HorizontalAlignment="Left">
+            <StackPanel>
+                <!-- Added Sender's Name -->
+                <TextBlock Text="{Binding SenderUsername}" Foreground="LightGray" 
+                       FontSize="12" FontWeight="Bold" Margin="5,0,5,2"/>
+                <Grid>
+                    <Border Background="Transparent" Padding="5" CornerRadius="10" Margin="5">
+                        <Image Source="{Binding ImageURL}" MaxWidth="200" Stretch="UniformToFill"/>
+                    </Border>
+                    <!-- Menu button for left messages (positioned on right side) -->
+                    <Button HorizontalAlignment="Right" VerticalAlignment="Top" 
+                            Background="Transparent" BorderThickness="0" Margin="0,0,-30,0"
+                            Width="30" Height="30">
+                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE10C;" Foreground="LightGray"/>
+                        <Button.Flyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem Text="Report" Icon="ReportHacked" Command="{Binding DataContext.ReportMessageCommand, ElementName=chatMessagesView}"
+                                CommandParameter="{Binding}"/>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="ImageMessageTemplateRight">
+        <Grid HorizontalAlignment="Right">
+            <StackPanel>
+                <!-- Added Sender's Name -->
+                <TextBlock Text="{Binding SenderUsername}" Foreground="LightGray" 
+                       FontSize="12" FontWeight="Bold" Margin="5,0,5,2"
+                       HorizontalAlignment="Right"/>
+                <Grid>
+                    <!-- Menu button for right messages (positioned on left side) -->
+                    <Button HorizontalAlignment="Left" VerticalAlignment="Top" 
+                            Background="Transparent" BorderThickness="0" Margin="-30,0,0,0"
+                            Width="30" Height="30">
+                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE10C;" Foreground="LightGray"/>
+                        <Button.Flyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem Text="Delete" 
+                                                Icon="Delete"
+                                                Command="{Binding DataContext.DeleteMessageCommand, ElementName=chatMessagesView}"
+                                                CommandParameter="{Binding}"/>
+                                <MenuFlyoutItem Text="Report" Icon="ReportHacked" Command="{Binding DataContext.ReportMessageCommand, ElementName=chatMessagesView}"
+CommandParameter="{Binding}"/>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+                    <Border Background="Transparent" Padding="5" CornerRadius="10" Margin="5">
+                        <Image Source="{Binding ImageURL}" MaxWidth="200" Stretch="UniformToFill"/>
+                    </Border>
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+
+    <!-- Transfer Message Templates -->
+    <DataTemplate x:Key="TransferMessageTemplateLeft">
+        <Grid HorizontalAlignment="Left">
+            <StackPanel>
+                <!-- Added Sender's Name -->
+                <TextBlock Text="{Binding SenderUsername}" Foreground="LightGray" 
+                       FontSize="12" FontWeight="Bold" Margin="5,0,5,2"/>
+                <Grid>
+                    <Border Background="#39374f" Padding="10" CornerRadius="10" Margin="5" MaxWidth="400">
+                        <StackPanel>
+                            <TextBlock Text="Sent:" Foreground="White" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding FormattedAmount }" 
+                                       Foreground="White" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding Description}" Foreground="White" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                    <!-- Menu button for left messages (positioned on right side) -->
+                    <Button HorizontalAlignment="Right" VerticalAlignment="Top" 
+                            Background="Transparent" BorderThickness="0" Margin="0,0,-30,0"
+                            Width="30" Height="30">
+                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE10C;" Foreground="LightGray"/>
+                        <Button.Flyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem Text="Report" Icon="ReportHacked" Command="{Binding DataContext.ReportMessageCommand, ElementName=chatMessagesView}"
+CommandParameter="{Binding}"/>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="TransferMessageTemplateRight">
+        <Grid HorizontalAlignment="Right">
+            <StackPanel>
+                <!-- Added Sender's Name -->
+                <TextBlock Text="{Binding SenderUsername}" Foreground="LightGray" 
+                       FontSize="12" FontWeight="Bold" Margin="5,0,5,2"
+                       HorizontalAlignment="Right"/>
+                <Grid>
+                    <!-- Menu button for right messages (positioned on left side) -->
+                    <Button HorizontalAlignment="Left" VerticalAlignment="Top" 
+                            Background="Transparent" BorderThickness="0" Margin="-30,0,0,0"
+                            Width="30" Height="30">
+                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE10C;" Foreground="LightGray"/>
+                        <Button.Flyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem Text="Delete"
+                                                Icon="Delete"
+                                                Command="{Binding DataContext.DeleteMessageCommand, ElementName=chatMessagesView}"
+                                                CommandParameter="{Binding}"/>
+                                <MenuFlyoutItem Text="Report" Icon="ReportHacked" Command="{Binding DataContext.ReportMessageCommand, ElementName=chatMessagesView}"
+CommandParameter="{Binding}"/>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+                    <Border Background="#4e6e8e" Padding="10" CornerRadius="10" Margin="5" MaxWidth="400">
+                        <StackPanel>
+                            <TextBlock Text="Sent:" Foreground="White" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding FormattedAmount }" 
+                                       Foreground="Black" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding Description}" Foreground="Black" TextWrapping="Wrap"/>
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+
+    <!-- Request Message Templates -->
+    <DataTemplate x:Key="RequestMessageTemplateLeft">
+        <Grid HorizontalAlignment="Left">
+            <StackPanel>
+                <!-- Added Sender's Name -->
+                <TextBlock Text="{Binding SenderUsername}" Foreground="LightGray" 
+                       FontSize="12" FontWeight="Bold" Margin="5,0,5,2"/>
+                <Grid>
+                    <Border Background="#39374f" Padding="10" CornerRadius="10" Margin="5" MaxWidth="400">
+                        <StackPanel>
+                            <TextBlock Text="Requested:" Foreground="White" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding FormattedAmount }" 
+                                       Foreground="White" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding Description}" Foreground="White" TextWrapping="Wrap"/>
+                            <Button Content="Accept Request" Background="#4CAF50" Foreground="White" 
+                                    HorizontalAlignment="Center" Padding="5" Margin="5" 
+                                    Command="{Binding AcceptRequestCommand}"/>
+                        </StackPanel>
+                    </Border>
+                    <!-- Menu button for left messages (positioned on right side) -->
+                    <Button HorizontalAlignment="Right" VerticalAlignment="Top" 
+                            Background="Transparent" BorderThickness="0" Margin="0,0,-30,0"
+                            Width="30" Height="30">
+                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE10C;" Foreground="LightGray"/>
+                        <Button.Flyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem Text="Report" Icon="ReportHacked" Command="{Binding DataContext.ReportMessageCommand, ElementName=chatMessagesView}"
+CommandParameter="{Binding}"/>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+
+    <DataTemplate x:Key="RequestMessageTemplateRight">
+        <Grid HorizontalAlignment="Right">
+            <StackPanel>
+                <!-- Added Sender's Name -->
+                <TextBlock Text="{Binding SenderUsername}" Foreground="LightGray" 
+                       FontSize="12" FontWeight="Bold" Margin="5,0,5,2"
+                       HorizontalAlignment="Right"/>
+                <Grid>
+                    <!-- Menu button for right messages (positioned on left side) -->
+                    <Button HorizontalAlignment="Left" VerticalAlignment="Top" 
+                            Background="Transparent" BorderThickness="0" Margin="-30,0,0,0"
+                            Width="30" Height="30">
+                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE10C;" Foreground="LightGray"/>
+                        <Button.Flyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem Text="Delete" 
+                                                Icon="Delete"
+                                                Command="{Binding DataContext.DeleteMessageCommand, ElementName=chatMessagesView}"
+                                                CommandParameter="{Binding}"/>
+                                <MenuFlyoutItem Text="Report" Icon="ReportHacked" Command="{Binding DataContext.ReportMessageCommand, ElementName=chatMessagesView}"
+CommandParameter="{Binding}"/>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
+                    <Border Background="#4e6e8e" Padding="10" CornerRadius="10" Margin="5" MaxWidth="400">
+                        <StackPanel>
+                            <TextBlock Text="You requested:" Foreground="White" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding FormattedAmount }" 
+                                       Foreground="Black" FontWeight="Bold"/>
+                            <TextBlock Text="{Binding Description}" Foreground="Black" TextWrapping="Wrap"/>
+                            
+                        </StackPanel>
+                    </Border>
+                </Grid>
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+</ResourceDictionary> 

--- a/BankAppDesktop/ViewModels/MessageTemplatesViewModel.cs
+++ b/BankAppDesktop/ViewModels/MessageTemplatesViewModel.cs
@@ -1,0 +1,121 @@
+using Common.Models.Social;
+using Common.Services.Social;
+using Microsoft.UI.Xaml;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+namespace BankAppDesktop.ViewModels
+{
+    public class MessageTemplatesViewModel : ViewModelBase
+    {
+        private readonly IMessageService _messageService;
+        private ObservableCollection<Message> _messages;
+        private int _currentChatId;
+
+        public MessageTemplatesViewModel(IMessageService messageService)
+        {
+            _messageService = messageService;
+            _messages = new ObservableCollection<Message>();
+            
+            // Initialize commands
+            DeleteMessageCommand = new RelayCommand<Message>(ExecuteDeleteMessage);
+            ReportMessageCommand = new RelayCommand<Message>(ExecuteReportMessage);
+            AcceptRequestCommand = new RelayCommand<Message>(ExecuteAcceptRequest);
+        }
+
+        public ObservableCollection<Message> Messages
+        {
+            get => _messages;
+            set
+            {
+                _messages = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public int CurrentChatId
+        {
+            get => _currentChatId;
+            set
+            {
+                _currentChatId = value;
+                OnPropertyChanged();
+                LoadMessages();
+            }
+        }
+
+        public ICommand DeleteMessageCommand { get; }
+        public ICommand ReportMessageCommand { get; }
+        public ICommand AcceptRequestCommand { get; }
+
+        private async void LoadMessages()
+        {
+            if (_currentChatId <= 0) return;
+
+            try
+            {
+                var messages = await _messageService.GetMessagesAsync(_currentChatId, 1, 20);
+                Messages.Clear();
+                foreach (var message in messages)
+                {
+                    Messages.Add(message);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Handle error (you might want to show a message to the user)
+                System.Diagnostics.Debug.WriteLine($"Error loading messages: {ex.Message}");
+            }
+        }
+
+        private async void ExecuteDeleteMessage(Message message)
+        {
+            if (message == null) return;
+
+            try
+            {
+                await _messageService.DeleteMessageAsync(_currentChatId, message.Id, message.Sender);
+                Messages.Remove(message);
+            }
+            catch (Exception ex)
+            {
+                // Handle error
+                System.Diagnostics.Debug.WriteLine($"Error deleting message: {ex.Message}");
+            }
+        }
+
+        private async void ExecuteReportMessage(Message message)
+        {
+            if (message == null) return;
+
+            try
+            {
+                await _messageService.ReportMessage(_currentChatId, message.Id, message.Sender, ReportReason.Other);
+                // You might want to show a success message to the user
+            }
+            catch (Exception ex)
+            {
+                // Handle error
+                System.Diagnostics.Debug.WriteLine($"Error reporting message: {ex.Message}");
+            }
+        }
+
+        private async void ExecuteAcceptRequest(Message message)
+        {
+            if (message == null || message.Type != MessageType.Request) return;
+
+            try
+            {
+                // Implement request acceptance logic here
+                // This might involve calling a different service method
+                // For now, we'll just remove the message
+                Messages.Remove(message);
+            }
+            catch (Exception ex)
+            {
+                // Handle error
+                System.Diagnostics.Debug.WriteLine($"Error accepting request: {ex.Message}");
+            }
+        }
+    }
+} 

--- a/BankAppWeb/Pages/Messages/Index.cshtml
+++ b/BankAppWeb/Pages/Messages/Index.cshtml
@@ -1,0 +1,68 @@
+@page
+@model BankAppWeb.Pages.Messages.IndexModel
+@using Common.Models.Social
+@{
+    ViewData["Title"] = "Messages";
+}
+
+<div class="container">
+    <h1>Messages</h1>
+
+    @if (!string.IsNullOrEmpty(Model.ViewModel.ErrorMessage))
+    {
+        <div class="alert alert-danger">
+            @Model.ViewModel.ErrorMessage
+        </div>
+    }
+
+    @if (!string.IsNullOrEmpty(Model.ViewModel.SuccessMessage))
+    {
+        <div class="alert alert-success">
+            @Model.ViewModel.SuccessMessage
+        </div>
+    }
+
+    <div class="messages-container">
+        @foreach (var message in Model.ViewModel.Messages)
+        {
+            var isSender = message.Sender.Id == Model.ViewModel.CurrentUserId;
+            var messageType = message.Type.ToString().ToLower();
+            var content = message.MessageContent;
+            string? imageUrl = null;
+            string? formattedAmount = null;
+            string? description = null;
+
+            if (message is ImageMessage imgMsg)
+            {
+                imageUrl = imgMsg.ImageUrl;
+            }
+            else if (message is TransferMessage transferMsg)
+            {
+                formattedAmount = transferMsg.FormattedAmount;
+                description = transferMsg.Description;
+            }
+            else if (message is RequestMessage requestMsg)
+            {
+                formattedAmount = requestMsg.FormattedAmount;
+                description = requestMsg.Description;
+            }
+
+            <partial name="_MessageTemplates" model="new {
+                Id = message.Id,
+                MessageType = messageType,
+                SenderUsername = message.Sender.UserName,
+                IsSender = isSender,
+                Content = content,
+                ImageURL = imageUrl,
+                FormattedAmount = formattedAmount,
+                Description = description
+            }" />
+        }
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        // Any additional JavaScript specific to this page
+    </script>
+} 

--- a/BankAppWeb/Pages/Messages/Index.cshtml.cs
+++ b/BankAppWeb/Pages/Messages/Index.cshtml.cs
@@ -1,0 +1,51 @@
+using BankAppWeb.ViewModels;
+using Common.Services;
+using Common.Services.Social;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BankAppWeb.Pages.Messages
+{
+    [Authorize]
+    public class IndexModel : PageModel
+    {
+        private readonly IMessageService _messageService;
+        private readonly IUserService _userService;
+
+        public IndexModel(IMessageService messageService, IUserService userService)
+        {
+            _messageService = messageService;
+            _userService = userService;
+            ViewModel = new MessageTemplatesViewModel(messageService, userService);
+        }
+
+        [BindProperty]
+        public MessageTemplatesViewModel ViewModel { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int chatId)
+        {
+            ViewModel.CurrentChatId = chatId;
+            await ViewModel.LoadMessagesAsync();
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostDeleteAsync(int messageId)
+        {
+            await ViewModel.DeleteMessageAsync(messageId);
+            return RedirectToPage(new { chatId = ViewModel.CurrentChatId });
+        }
+
+        public async Task<IActionResult> OnPostReportAsync(int messageId)
+        {
+            await ViewModel.ReportMessageAsync(messageId);
+            return RedirectToPage(new { chatId = ViewModel.CurrentChatId });
+        }
+
+        public async Task<IActionResult> OnPostAcceptRequestAsync(int messageId)
+        {
+            await ViewModel.AcceptRequestAsync(messageId);
+            return RedirectToPage(new { chatId = ViewModel.CurrentChatId });
+        }
+    }
+} 

--- a/BankAppWeb/ViewModels/MessageTemplatesViewModel.cs
+++ b/BankAppWeb/ViewModels/MessageTemplatesViewModel.cs
@@ -1,0 +1,147 @@
+using Common.Models.Social;
+using Common.Services.Social;
+using Common.Services;
+using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.DataAnnotations;
+
+namespace BankAppWeb.ViewModels
+{
+    public class MessageTemplatesViewModel
+    {
+        private readonly IMessageService _messageService;
+        private readonly IUserService _userService;
+
+        public MessageTemplatesViewModel(IMessageService messageService, IUserService userService)
+        {
+            _messageService = messageService;
+            _userService = userService;
+            Messages = new List<Message>();
+        }
+
+        public List<Message> Messages { get; set; }
+        public int CurrentChatId { get; set; }
+        public string? ErrorMessage { get; set; }
+        public string? SuccessMessage { get; set; }
+        public int CurrentUserId { get; set; }
+
+        public InputModel Input { get; set; } = new();
+
+        public class InputModel
+        {
+            [Required]
+            public string Content { get; set; } = string.Empty;
+
+            [Required]
+            public MessageType Type { get; set; }
+
+            public string? ImageUrl { get; set; }
+            public float? Amount { get; set; }
+            public string? Description { get; set; }
+            public string? Currency { get; set; }
+        }
+
+        public async Task LoadMessagesAsync()
+        {
+            try
+            {
+                var user = await _userService.GetCurrentUserAsync();
+                if (user == null)
+                {
+                    ErrorMessage = "User not found";
+                    return;
+                }
+
+                CurrentUserId = user.Id;
+                Messages = await _messageService.GetMessagesAsync(CurrentChatId, 1, 20);
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage = $"Error loading messages: {ex.Message}";
+            }
+        }
+
+        public async Task DeleteMessageAsync(int messageId)
+        {
+            try
+            {
+                var user = await _userService.GetCurrentUserAsync();
+                if (user == null)
+                {
+                    ErrorMessage = "User not found";
+                    return;
+                }
+
+                var message = Messages.FirstOrDefault(m => m.Id == messageId);
+                if (message == null)
+                {
+                    ErrorMessage = "Message not found";
+                    return;
+                }
+
+                await _messageService.DeleteMessageAsync(CurrentChatId, messageId, user);
+                Messages.Remove(message);
+                SuccessMessage = "Message deleted successfully";
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage = $"Error deleting message: {ex.Message}";
+            }
+        }
+
+        public async Task ReportMessageAsync(int messageId)
+        {
+            try
+            {
+                var user = await _userService.GetCurrentUserAsync();
+                if (user == null)
+                {
+                    ErrorMessage = "User not found";
+                    return;
+                }
+
+                var message = Messages.FirstOrDefault(m => m.Id == messageId);
+                if (message == null)
+                {
+                    ErrorMessage = "Message not found";
+                    return;
+                }
+
+                await _messageService.ReportMessage(CurrentChatId, messageId, user, ReportReason.Other);
+                SuccessMessage = "Message reported successfully";
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage = $"Error reporting message: {ex.Message}";
+            }
+        }
+
+        public async Task AcceptRequestAsync(int messageId)
+        {
+            try
+            {
+                var user = await _userService.GetCurrentUserAsync();
+                if (user == null)
+                {
+                    ErrorMessage = "User not found";
+                    return;
+                }
+
+                var message = Messages.FirstOrDefault(m => m.Id == messageId);
+                if (message == null || message.Type != MessageType.Request)
+                {
+                    ErrorMessage = "Invalid request message";
+                    return;
+                }
+
+                // Implement request acceptance logic here
+                // This might involve calling a different service method
+                Messages.Remove(message);
+                SuccessMessage = "Request accepted successfully";
+            }
+            catch (Exception ex)
+            {
+                ErrorMessage = $"Error accepting request: {ex.Message}";
+            }
+        }
+    }
+} 

--- a/BankAppWeb/Views/Shared/_Layout.cshtml
+++ b/BankAppWeb/Views/Shared/_Layout.cshtml
@@ -10,6 +10,7 @@
     <script type="importmap"></script>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/message-templates.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/BankAppWeb.styles.css" asp-append-version="true" />
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
@@ -116,6 +117,7 @@
     <script src="~/lib/jquery/dist/jquery.min.js"></script>
     <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
+    <script src="~/js/message-templates.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/BankAppWeb/Views/Shared/_MessageTemplates.cshtml
+++ b/BankAppWeb/Views/Shared/_MessageTemplates.cshtml
@@ -1,0 +1,47 @@
+@model dynamic
+
+@{
+    var messageType = Model.MessageType;
+    var alignment = Model.IsSender ? "right" : "left";
+    var messageClass = $"{messageType}-message {alignment}";
+}
+
+<div class="message-container @alignment" data-message-id="@Model.Id">
+    <div class="@messageClass">
+        <div class="sender-name">@Model.SenderUsername</div>
+        <div class="message-content">
+            @switch (messageType)
+            {
+                case "text":
+                    <div>@Model.Content</div>
+                    break;
+                case "image":
+                    <img src="@Model.ImageURL" alt="Message image" />
+                    break;
+                case "transfer":
+                    <div>
+                        <div>Sent:</div>
+                        <div class="amount">@Model.FormattedAmount</div>
+                        <div>@Model.Description</div>
+                    </div>
+                    break;
+                case "request":
+                    <div>
+                        <div>@(Model.IsSender ? "You requested:" : "Requested:")</div>
+                        <div class="amount">@Model.FormattedAmount</div>
+                        <div>@Model.Description</div>
+                        @if (!Model.IsSender)
+                        {
+                            <button class="accept-request-btn" onclick="messageTemplates.acceptRequest('@Model.Id')">
+                                Accept Request
+                            </button>
+                        }
+                    </div>
+                    break;
+            }
+            <button class="message-menu-btn @alignment">
+                <i class="fas fa-ellipsis-v"></i>
+            </button>
+        </div>
+    </div>
+</div> 

--- a/BankAppWeb/wwwroot/css/message-templates.css
+++ b/BankAppWeb/wwwroot/css/message-templates.css
@@ -1,0 +1,134 @@
+/* Message Templates Styles */
+
+/* Common styles for all messages */
+.message-container {
+    display: flex;
+    margin: 10px 0;
+}
+
+.message-container.left {
+    justify-content: flex-start;
+}
+
+.message-container.right {
+    justify-content: flex-end;
+}
+
+.sender-name {
+    color: #d3d3d3;
+    font-size: 12px;
+    font-weight: bold;
+    margin: 5px 0;
+}
+
+.message-content {
+    max-width: 400px;
+    padding: 10px;
+    border-radius: 10px;
+    position: relative;
+}
+
+/* Text Messages */
+.text-message.left .message-content {
+    background-color: #39374f;
+    color: white;
+}
+
+.text-message.right .message-content {
+    background-color: #4e6e8e;
+    color: white;
+}
+
+/* Image Messages */
+.image-message .message-content {
+    background-color: transparent;
+    padding: 5px;
+}
+
+.image-message img {
+    max-width: 200px;
+    border-radius: 10px;
+}
+
+/* Transfer Messages */
+.transfer-message.left .message-content {
+    background-color: #39374f;
+    color: white;
+}
+
+.transfer-message.right .message-content {
+    background-color: #4e6e8e;
+}
+
+.transfer-message .amount {
+    font-weight: bold;
+}
+
+/* Request Messages */
+.request-message.left .message-content {
+    background-color: #39374f;
+    color: white;
+}
+
+.request-message.right .message-content {
+    background-color: #4e6e8e;
+}
+
+.accept-request-btn {
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    padding: 5px 10px;
+    border-radius: 5px;
+    cursor: pointer;
+    margin: 5px auto;
+    display: block;
+}
+
+/* Message Menu */
+.message-menu-btn {
+    background: transparent;
+    border: none;
+    width: 30px;
+    height: 30px;
+    position: absolute;
+    top: 0;
+    cursor: pointer;
+}
+
+.message-menu-btn.left {
+    right: -30px;
+}
+
+.message-menu-btn.right {
+    left: -30px;
+}
+
+.message-menu-btn i {
+    color: #d3d3d3;
+}
+
+/* Menu Items */
+.message-menu {
+    position: absolute;
+    background: white;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+    z-index: 1000;
+}
+
+.message-menu-item {
+    padding: 8px 15px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.message-menu-item:hover {
+    background-color: #f5f5f5;
+}
+
+.message-menu-item i {
+    margin-right: 5px;
+} 

--- a/BankAppWeb/wwwroot/js/message-templates.js
+++ b/BankAppWeb/wwwroot/js/message-templates.js
@@ -1,0 +1,153 @@
+// Message Templates JavaScript
+
+class MessageTemplates {
+    constructor() {
+        this.initializeEventListeners();
+    }
+
+    initializeEventListeners() {
+        // Handle message menu buttons
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('.message-menu-btn')) {
+                this.toggleMessageMenu(e);
+            } else if (!e.target.closest('.message-menu')) {
+                this.closeAllMenus();
+            }
+        });
+
+        // Handle menu items
+        document.addEventListener('click', (e) => {
+            const menuItem = e.target.closest('.message-menu-item');
+            if (menuItem) {
+                this.handleMenuItemClick(menuItem);
+            }
+        });
+    }
+
+    toggleMessageMenu(event) {
+        const button = event.target.closest('.message-menu-btn');
+        const messageContainer = button.closest('.message-container');
+        const existingMenu = messageContainer.querySelector('.message-menu');
+
+        // Close all other menus first
+        this.closeAllMenus();
+
+        if (!existingMenu) {
+            const menu = this.createMessageMenu(button);
+            messageContainer.appendChild(menu);
+        }
+    }
+
+    createMessageMenu(button) {
+        const menu = document.createElement('div');
+        menu.className = 'message-menu';
+        
+        // Determine if this is a right-aligned message (sender's own message)
+        const isRightMessage = button.closest('.message-container').classList.contains('right');
+        
+        if (isRightMessage) {
+            menu.innerHTML = `
+                <div class="message-menu-item" data-action="delete">
+                    <i class="fas fa-trash"></i> Delete
+                </div>
+                <div class="message-menu-item" data-action="report">
+                    <i class="fas fa-flag"></i> Report
+                </div>
+            `;
+        } else {
+            menu.innerHTML = `
+                <div class="message-menu-item" data-action="report">
+                    <i class="fas fa-flag"></i> Report
+                </div>
+            `;
+        }
+
+        return menu;
+    }
+
+    closeAllMenus() {
+        document.querySelectorAll('.message-menu').forEach(menu => menu.remove());
+    }
+
+    handleMenuItemClick(menuItem) {
+        const action = menuItem.dataset.action;
+        const messageContainer = menuItem.closest('.message-container');
+        const messageId = messageContainer.dataset.messageId;
+
+        switch (action) {
+            case 'delete':
+                this.deleteMessage(messageId);
+                break;
+            case 'report':
+                this.reportMessage(messageId);
+                break;
+        }
+
+        this.closeAllMenus();
+    }
+
+    async deleteMessage(messageId) {
+        try {
+            const response = await fetch(`/api/messages/${messageId}`, {
+                method: 'DELETE',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (response.ok) {
+                const messageContainer = document.querySelector(`[data-message-id="${messageId}"]`);
+                messageContainer.remove();
+            } else {
+                console.error('Failed to delete message');
+            }
+        } catch (error) {
+            console.error('Error deleting message:', error);
+        }
+    }
+
+    async reportMessage(messageId) {
+        try {
+            const response = await fetch(`/api/messages/${messageId}/report`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (response.ok) {
+                // Show success notification
+                alert('Message reported successfully');
+            } else {
+                console.error('Failed to report message');
+            }
+        } catch (error) {
+            console.error('Error reporting message:', error);
+        }
+    }
+
+    async acceptRequest(messageId) {
+        try {
+            const response = await fetch(`/api/messages/${messageId}/accept`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (response.ok) {
+                // Show success notification
+                alert('Request accepted successfully');
+            } else {
+                console.error('Failed to accept request');
+            }
+        } catch (error) {
+            console.error('Error accepting request:', error);
+        }
+    }
+}
+
+// Initialize message templates when the DOM is loaded
+document.addEventListener('DOMContentLoaded', () => {
+    window.messageTemplates = new MessageTemplates();
+}); 


### PR DESCRIPTION
- Introduced `MessageTemplates.xaml` for defining various message templates (text, image, transfer, request).
- Created `MessageTemplatesViewModel` to manage message data and commands (delete, report, accept request).
- Updated `Index.cshtml` and its code-behind to utilize the new view model and render messages using the templates.
- Added JavaScript functionality for handling message menu actions (delete, report, accept request).
- Included CSS for styling message templates and their interactions.