### PR TITLE
Fix User Information Pane Update in Analysis Page

### DIFF
--- a/BankAppWeb/Pages/Analysis/Index.cshtml.cs
+++ b/BankAppWeb/Pages/Analysis/Index.cshtml.cs
@@ -44,8 +44,8 @@ namespace BankAppWeb.Pages.Analysis
         {
             try
             {
-                CurrentUser = await _userService.GetCurrentUserAsync();
-                if (CurrentUser == null)
+                var currentUser = await _userService.GetCurrentUserAsync();
+                if (currentUser == null)
                 {
                     ErrorMessage = "Unable to identify user. Please log in again.";
                     return Page();
@@ -62,11 +62,14 @@ namespace BankAppWeb.Pages.Analysis
                     {
                         Value = u.CNP,
                         Text = $"{u.UserName} - {u.FirstName} {u.LastName}",
-                        Selected = u.CNP == (userCnp ?? CurrentUser.CNP)
+                        Selected = u.CNP == (userCnp ?? currentUser.CNP)
                     })];
 
                     // Set the selected user CNP
-                    SelectedUserCnp = userCnp ?? CurrentUser.CNP;
+                    SelectedUserCnp = userCnp ?? currentUser.CNP;
+
+                    // Get the selected user's information
+                    CurrentUser = users.FirstOrDefault(u => u.CNP == SelectedUserCnp) ?? currentUser;
 
                     // Get activities for selected user
                     Activities = await _activityService.GetActivityForUser(SelectedUserCnp);
@@ -74,7 +77,8 @@ namespace BankAppWeb.Pages.Analysis
                 else
                 {
                     // Regular user - only get their own activities
-                    SelectedUserCnp = CurrentUser.CNP;
+                    SelectedUserCnp = currentUser.CNP;
+                    CurrentUser = currentUser;
                     Activities = await _activityService.GetActivityForUser(CurrentUser.CNP);
                 }
 


### PR DESCRIPTION
# Fix User Information Pane Update in Analysis Page

## Issue
When changing a selected user's admin status in the Analysis page, the user information pane was not updating to reflect the changes, while the charts were updating correctly. This created an inconsistent user experience where the visual representation of the user's admin status was out of sync with the actual data.

## Changes Made
Modified the `OnGetAsync` method in `Analysis/Index.cshtml.cs` to properly load and display the selected user's information when in admin mode. The key changes include:

1. Storing the current user in a local variable instead of directly in the `CurrentUser` property
2. When in admin mode:
   - Loading the selected user's complete information from the users list
   - Setting the `CurrentUser` property to the selected user's data
3. Maintaining the existing behavior for regular users (showing only their own information)

## Testing Instructions
1. Log in as an admin user
2. Navigate to the Analysis page
3. Select a user from the dropdown menu
4. Click the "Go" button to load their information
5. Verify that:
   - The user information pane updates
   - The charts continue to update correctly (existing functionality)

## Technical Details
- The fix ensures that the user information pane stays in sync with the selected user's data
- Maintains the existing form submission pattern with the "Go" button for user selection
- No changes to the chart update functionality, which was already working correctly

## Impact
This change improves the user experience by ensuring consistent data display across all UI elements when managing user admin statuses.